### PR TITLE
Lowercase training id when disassociating

### DIFF
--- a/training/management/commands/disassociate_training_roles.py
+++ b/training/management/commands/disassociate_training_roles.py
@@ -16,6 +16,6 @@ class Command(BaseCommand):
         for event in Training.objects.filter(end__lte=yesterday):
             print(f"Removing users from {event}")
             try:
-                print(disassociate_role(event.training_identifier, commit=commit))
+                print(disassociate_role(event.training_identifier.lower(), commit=commit))
             except ProgrammingError as pe:
                 print(pe)


### PR DESCRIPTION
A small fix:
Some trainers wrote capital letters in their training identifier. The id is switched to lowercase before role creation/association, but it was not done for disassociation => the users stayed in the role (and their job got stuck as the reservation wasn't active anymore).
"Tested in production" on .fr :D