### PR TITLE
Fix calendar render

### DIFF
--- a/training/templates/training/calendar.html
+++ b/training/templates/training/calendar.html
@@ -206,7 +206,7 @@
 
                   <tr>
                     <td>Description</td>
-                    <td> <small>{{ selectedEvent.description|safe }}</small> </td>
+                    <td> <small v-html="selectedEvent.description"></small> </td>
                   </tr>
                 </table>
                 {% endverbatim %}
@@ -260,7 +260,7 @@
 
 {% block script %}
 
-<script src='https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.min.js'></script>
 <script src='https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js'></script>
 
 <script>
@@ -329,7 +329,9 @@
             title: "{{ event.title }}",
             organiser: "{{ event.name }}",
             email: "{{ event.email }}",
-            description: "{{ event.description }}",
+            {% spaceless %}
+            description: "{{ event.description|linebreaksbr }}",
+            {% endspaceless %}
             website: "{{ event.website }}",
             location: "{{ event.str_locations }}",
             use_gtn: "{{ event.use_gtn|yesno:'Yes,No' }}",

--- a/training/templates/training/calendar.html
+++ b/training/templates/training/calendar.html
@@ -206,7 +206,7 @@
 
                   <tr>
                     <td>Description</td>
-                    <td> <small>{{ selectedEvent.description }}</small> </td>
+                    <td> <small>{{ selectedEvent.description|safe }}</small> </td>
                   </tr>
                 </table>
                 {% endverbatim %}
@@ -282,11 +282,16 @@
     vuetify: new Vuetify(),
     data () {
       const dateStr = new Date().toISOString().slice(0, 10)
-      const y = dateStr.split('-')[0]
       const month = new Date().getMonth() + 1;
       const zeroPad = (m) => m < 10 ? `0${m}` : `${m}`;
+      const y = parseInt(dateStr.split('-')[0])
       const addMonths = (n) => {
-        const m = zeroPad(month + n)
+        let m = zeroPad(month + n)
+        let year = y
+        if (m > 12) {
+          m = m - 12
+          year += 1
+        }
         return `${y}-${m}-01`
       }
       const defaultDates = [


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tiaas2/issues/52 by replacing newlines with spaceless `<br>` tags when rendering event descriptions. 

Also switched Vue CDN link to a prod release.

Also fixes the issue of calendar panel months being wrong:

![image](https://user-images.githubusercontent.com/42562517/199966305-f6295450-51ce-430d-9f64-2213bf0e1c9d.png)
