### PR TITLE
fix invalid comparision

### DIFF
--- a/tiaas/settings.py
+++ b/tiaas/settings.py
@@ -15,7 +15,6 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 import os
 
 from tiaas import git
-from tiaas.logging import LOGGING
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/training/views.py
+++ b/training/views.py
@@ -296,7 +296,7 @@ def join(request, training_id):
         datetime.now()
         - timedelta(hours=settings.TIAAS_JOIN_TRAINING_FLEX_HOURS)
     )
-    if event.end < tz_flexible_now:
+    if event.end < tz_flexible_now.date():
         return render(
             request,
             "training/error.html",


### PR DESCRIPTION
fixes the following traceback:

```
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]: Traceback (most recent call last):
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:   File "/opt/tiaas2/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:     response = get_response(request)
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:   File "/opt/tiaas2/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:     response = wrapped_callback(request, *callback_args, **callback_kwargs)
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:   File "/opt/tiaas2/code/training/views.py", line 299, in join
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]:     if event.end < tz_flexible_now:
Jan 09 06:23:57 sn06.galaxyproject.eu gunicorn[2190403]: TypeError: can't compare datetime.datetime to datetime.date

```