### PR TITLE
Fix get_commit_id when pinned to a specific commit

### DIFF
--- a/tiaas/git.py
+++ b/tiaas/git.py
@@ -15,13 +15,13 @@ def get_commit_id(base_dir):
     # Open the correct file in .git\ref\heads\[branch]
     if " " in git_head_data:
         git_head_ref = os.path.join(base_dir, ".git", git_head_data.split(" ")[1],)
+
+        # Get the commit hash ([:7] used to get "--short")
+        with open(git_head_ref, "r") as f:
+            return f.read().strip()
     else:
         # When pinned to a specific commit
-        git_head_ref = os.path.join(base_dir, ".git", git_head_data)
-
-    # Get the commit hash ([:7] used to get "--short")
-    with open(git_head_ref, "r") as f:
-        return f.read().strip()
+        return git_head_data[:7]
 
 
 def get_remote_url(base_dir):


### PR DESCRIPTION
A follow up to fix https://github.com/galaxyproject/tiaas2/issues/40, looks like https://github.com/galaxyproject/tiaas2/commit/dbca03259654d698c2793098aa172fc8de05eca2 was not enough