### PR TITLE
Fix calendar date again

### DIFF
--- a/training/templates/training/calendar.html
+++ b/training/templates/training/calendar.html
@@ -287,6 +287,7 @@
     data () {
       const addMonths = (n) => {
         const d = new Date();
+        d.setDate(1);
         d.setMonth(d.getMonth() + n);
         return d.toISOString().slice(0, 10)
       }


### PR DESCRIPTION
Another bug spotted by @bgruening. On the last day(s) of the month the date transition function can generate a non-existent date like `30-03-23` when the following month has more days than the current.

Once again, date/times are my kryptonite.