### PR TITLE
Use TIAAS_LATE_REQUEST_PREVENTION_DAYS in snippets

### DIFF
--- a/templates/snippets/about/3_eligibility.html
+++ b/templates/snippets/about/3_eligibility.html
@@ -5,6 +5,6 @@
 </p>
 
 <p class="alert alert-warning">
-  Please register <b>at least 2 weeks</b> before your event in order to be
+  Please register <b>at least {{ settings.TIAAS_LATE_REQUEST_PREVENTION_DAYS }} days</b> before your event in order to be
   approved!
 </p>


### PR DESCRIPTION
A small change I made during the deployment of .fr to have a message consistent with the duration of the prevention chosen for training requests.