### PR TITLE
fix DISASSOCIATE_ROLES_QUERY

### DIFF
--- a/training/galaxy.py
+++ b/training/galaxy.py
@@ -128,7 +128,7 @@ WHERE
             role
         WHERE
             type = 'system'
-            AND name = 'training-' || %s
+            AND name LIKE 'training-%' || %s
     )
 """
 

--- a/training/galaxy.py
+++ b/training/galaxy.py
@@ -128,7 +128,7 @@ WHERE
             role
         WHERE
             type = 'system'
-            AND name LIKE 'training-%' || %s
+            AND name LIKE 'training-%%' || %s
     )
 """
 


### PR DESCRIPTION
I spotted a bug. The query returns nothing ...   
```
galaxy=> SELECT * FROM role WHERE type = 'system' AND name = 'training-%';
 id | create_time | update_time | name | description | type | deleted 
----+-------------+-------------+------+-------------+------+---------
(0 rows)
```   

Seems better with   
```
galaxy=> SELECT * FROM role WHERE type = 'system' AND name LIKE 'training-%';
  id  |        create_time         |        update_time         |             name              |    description     |  type  | deleted 
------+----------------------------+----------------------------+-------------------------------+--------------------+--------+---------
 4167 | 2023-03-08 10:13:01.180001 | 2023-03-08 10:13:01.180001 | training-bililledna           | Autogenerated role | system | f
 4162 | 2023-03-07 09:22:59.312677 | 2023-03-07 09:22:59.312677 | training-bilillegalaxy        | Autogenerated role | system | f
```