### PR TITLE
update django-countries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dateparser==0.7.2
 Django==3.2.24
 django-bootstrap3==21.2
-django-countries==5.5
+django-countries==7.5.1
 django-prometheus==2.2.0
 gunicorn==20.1.0
 psycopg2-binary==2.9.6


### PR DESCRIPTION
the django-countries package has become too old for the django version and causes the error 

```
  File "/opt/tiaas/code/./manage.py", line 21, in <module>
    main()
  File "/opt/tiaas/code/./manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/commands/migrate.py", line 75, in handle
    self.check(databases=[database])
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/management/base.py", line 419, in check
    all_issues = checks.run_checks(
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/checks/registry.py", line 76, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/core/checks/model_checks.py", line 34, in check_all_models
    errors.extend(model.check(**kwargs))
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/db/models/base.py", line 1284, in check
    *cls._check_fields(**kwargs),
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/db/models/base.py", line 1395, in _check_fields
    errors.extend(field.check(**kwargs))
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django_countries/fields.py", line 293, in check
    errors = super(CountryField, self).check(**kwargs)
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 1013, in check
    *self._check_db_collation(databases),
  File "/opt/tiaas/venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py", line 1045, in _check_db_collation
    self.db_collation is None or
AttributeError: 'CountryField' object has no attribute 'db_collation'
```