### PR TITLE
add sentry support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2-binary==2.9.6
 pycryptodome==3.19.1
 factory_boy
 whitenoise==6.2.0
+sentry-sdk==2.14.0

--- a/tiaas/settings.py
+++ b/tiaas/settings.py
@@ -171,3 +171,16 @@ GALAXY_URL = f"http://{GALAXY_DOMAIN}"
 
 GIT_COMMIT_ID = git.get_commit_id(BASE_DIR)
 GIT_REMOTE_URL = git.get_remote_url(BASE_DIR)
+
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+if 'SENTRY_DSN' in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ['SENTRY_DSN'],
+        integrations=[
+            DjangoIntegration(),
+        ],
+        traces_sample_rate=0.1,
+        send_default_pii=False  # requires use of django.contrib.auth which we do not use.
+    )


### PR DESCRIPTION
Ansible users will likely want to copy and paste the following into their `tiaas_other_config` variable, as the enviornment variables aren't exposed by default by the ansible role.

```python
sentry_sdk.init(
    dsn="https://your.sentry.dsn.example.com",
    integrations=[
        DjangoIntegration(),
    ],
    traces_sample_rate=0.1, # Set to whatever, 1.0 is actually probably fine, tiaas gets low traffic.
    send_default_pii=False # requires use of django.contrib.auth which we do not use.
)
```