### PR TITLE
Fix double join error /unique user group association

### DIFF
--- a/training/galaxy.py
+++ b/training/galaxy.py
@@ -201,17 +201,18 @@ def create_group(training_id, role_id):
     )
     return group_id
 
+
 def add_group_user(group_id, user_id):
     existing = fetch_one(
         "select 1 from user_group_association where user_id = %s and group_id = %s",
-        (user_id, group_id)
+        (user_id, group_id),
     )
 
     if existing is None:
         execute(
             "insert into user_group_association (user_id, group_id, create_time, update_time) "
             "values (%s, %s, now(), now())",
-            (user_id, group_id)
+            (user_id, group_id),
         )
 
 
@@ -233,11 +234,13 @@ def execute_txn(query, params=None, commit=False):
         except IntentionalRollback:
             pass
 
+
 def fetch_one(query, params=None):
     with connections["galaxy"].cursor() as cursor:
         cursor.execute(query, params)
         result = cursor.fetchone()  # fetch one row
     return result
+
 
 def fetch_all(query, params=None):
     with connections["galaxy"].cursor() as cursor:

--- a/training/galaxy.py
+++ b/training/galaxy.py
@@ -203,17 +203,11 @@ def create_group(training_id, role_id):
 
 
 def add_group_user(group_id, user_id):
-    existing = fetch_one(
-        "select 1 from user_group_association where user_id = %s and group_id = %s",
+    execute(
+        "insert into user_group_association (user_id, group_id, create_time, update_time) "
+        "values (%s, %s, now(), now()) on conflict do nothing",
         (user_id, group_id),
     )
-
-    if existing is None:
-        execute(
-            "insert into user_group_association (user_id, group_id, create_time, update_time) "
-            "values (%s, %s, now(), now())",
-            (user_id, group_id),
-        )
 
 
 def execute(query, params=None):
@@ -233,13 +227,6 @@ def execute_txn(query, params=None, commit=False):
                 return result
         except IntentionalRollback:
             pass
-
-
-def fetch_one(query, params=None):
-    with connections["galaxy"].cursor() as cursor:
-        cursor.execute(query, params)
-        result = cursor.fetchone()  # fetch one row
-    return result
 
 
 def fetch_all(query, params=None):


### PR DESCRIPTION
thanks to @sanjaysrikakulam
closes https://github.com/usegalaxy-eu/issues/issues/681
Private issue summary:

TIaaS shows a 500 error when a user uses a `join-training` link twice.
It fails when trying to insert the same group and user again into the database.
The reason might be that the table was changed to `UNIQUE`

This fix was tested, so it should be safe to merge